### PR TITLE
Fix broken counting of paren-wrapped numbers

### DIFF
--- a/ScriptCards_API/1.4.0/scriptcards.js
+++ b/ScriptCards_API/1.4.0/scriptcards.js
@@ -2768,7 +2768,11 @@ const ScriptCards = (() => { // eslint-disable-line no-unused-vars
 				//rollResult.Text += `${currentOperator} `;
 				rollResult.Text += currentOperator == "*" ? "x " : currentOperator + " ";
 			}
-			
+
+			// A bare number within parens (just strip them)
+			if (text.match(/^\([+-]?(\d*\.)?\d*\)$/)) {
+				text = text.substring(1, text.length - 1)
+			}
 			// Just a number
 			if (text.match(/^[+-]?(\d*\.)?\d*$/)) {
 				componentHandled = true;


### PR DESCRIPTION
When a number is a bare number wrapped in parens (e.g., the way [*R:atkprofflag] is returned with the proficiency bonus within parens if proficient) it is ignored when counting up totals.

Example:
  A nat 20 on this roll:           1d20 + [*R:atkattr_base] + [*R:atkprofflag]
  Should resolve to:              1d20 (20) + 3 + (3) = 26
  But instead resolves to:      1d20 (20) + 3 = 23

This fix strips parens from around bare numbers.  It should handle the most common cases, but better paren parsing is probably a good idea in the long run.